### PR TITLE
Bugfix for Parsing Misc Entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.class
 /MibTeX/bin/*.gitignore
 /.metadata/
+
+# IntelliJ
+/MibTeX/.idea
+/MibTeX/MibTeX.iml

--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -165,7 +165,7 @@ public class BibtexEntry {
 			StringTokenizer tokenizer = new StringTokenizer(author, ",");
 			while (tokenizer.hasMoreTokens())
 				authorList.add(tokenizer.nextToken().trim());
-		} catch (Exception e) {
+		} catch (Exception e) { // What types of exceptions are expected here?
 			if (authorList.equals(UNKNOWN_ATTRIBUTE))
 				authorList.add(author);
 			e.printStackTrace();
@@ -173,21 +173,16 @@ public class BibtexEntry {
 	}
 
 	void parseTitle() {
-		try {
-			if (title.equals(UNKNOWN_ATTRIBUTE)) {
-				Value field = entry.getField(BibTeXEntry.KEY_TITLE);
-				if (field == null) {
-					title = EMPTY_ATTRIBUTE;
-					if (!isMisc()) {
-						System.err.println("[BibtexEntry.parseTitle] Warning: " + key + " does not have a title!");
-					}
-				} else {
-					title = field.toUserString();
+		if (title.equals(UNKNOWN_ATTRIBUTE)) {
+			Value field = entry.getField(BibTeXEntry.KEY_TITLE);
+			if (field == null) {
+				title = EMPTY_ATTRIBUTE;
+				if (!isMisc()) {
+					System.err.println("[BibtexEntry.parseTitle] Warning: " + key + " does not have a title!");
 				}
+			} else {
+				title = field.toUserString();
 			}
-		} catch (Exception e) {
-			System.out.println("parseTitle failed for " + key);
-			e.printStackTrace();
 		}
 		title = replaceUmlauts(title);
 	}


### PR DESCRIPTION
Hi Thomas,

For misc entries, no fields are required in BibTeX.
However, MibTeX attempts to parse authors and titles from each entry and throws an exception if this is not possible.
Thus, MibTeX crashes with the newest BibTags version because we have many new misc entries.
This PR is a bugfix for this issue.

I refactored parsing of authors and title to not be exception-based but perform necessary checks preemptively.
When a title or author is missing, a warning is printed for non-misc entries.