### PR TITLE
Made Authors Optional in HTML Export and PDF Name Because of Misc Entries

### DIFF
--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -96,17 +96,21 @@ public class BibtexEntry {
 	}
 
 	public File getPDFPath() {
-		String pdf = getLastname(authorList.get(0));
-		if (authorList.size() == 2)
-			pdf += " and " + getLastname(authorList.get(1));
-		else if (authorList.size() > 2)
-			pdf += " et al.";
+		String pdf = "";
+		
+		if (!authorList.isEmpty()) {
+			pdf += getLastname(authorList.get(0));
+			if (authorList.size() == 2)
+				pdf += " and " + getLastname(authorList.get(1));
+			else if (authorList.size() > 2)
+				pdf += " et al.";
+		}
 		if (!venue.startsWith("("))
 			pdf += " " + venue;
 		if (year > 0)
 			pdf += " " + year;
 		pdf += " " + title;
-		pdf += ".pdf";
+		pdf = pdf.trim() + ".pdf";
 		return new File(BibtexViewer.PDF_DIR, toURL(pdf));
 	}
 

--- a/MibTeX/src/de/mibtex/export/ExportNewHTML.java
+++ b/MibTeX/src/de/mibtex/export/ExportNewHTML.java
@@ -79,8 +79,16 @@ public class ExportNewHTML extends Export {
     }
 
     private String generateAuthorLinks(BibtexEntry entry) {
+    	List<String> authors;
+        if (entry.authorList.isEmpty()) {
+        	authors = new ArrayList<>(1);
+        	authors.add("unknown");
+        } else {
+        	authors = entry.authorList;
+        }
+
         StringBuilder HTML = new StringBuilder();
-        for (String author : entry.authorList) {
+        for (String author : authors) {
             HTML.append("<a href=\"\" onclick=\"setTag('searchAuthor','").append(author.trim())
                 .append("');event.preventDefault();Filter();\">").append(author).append("</a>, ");
         }

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -56,12 +56,12 @@ public class ExportTypo3Bibtex extends Export {
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
 			//Filters.Any()
-			//Filters.KeyIsOneOf("BTS:SEFM19")
+			Filters.keyIsOneOf("KTSB:ICSE21")
 			//Filters.WithThomasAtUlm
 			//Filters.WithPaulAtUlm
 			//Filters.WithPaulBeforeOrNotAtUlm
 			//Filters.WithPaul.and(Filters.WithThomasBeforeUlm)
-			Filters.WITH_CHICO
+			//Filters.WITH_CHICO
 			;
 
 	/**


### PR DESCRIPTION
Emergency fix for not letting MibTeX crash.
Changes:

In ExportHTMLNew: If there are no authors for an entry, "unknown" is displayed on the website.

In BibtexEntry.getPDFPath(): Authors are ommitted in PDF path when there are no authors.