### PR TITLE
Bugfix in Concatenating Empty Paths

### DIFF
--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -109,13 +109,17 @@ public class BibtexEntry {
 			pdf += " " + venue;
 		if (year > 0)
 			pdf += " " + year;
-		pdf += " " + title;
+		if (!EMPTY_ATTRIBUTE.equals(title)) {
+			pdf += " " + title;
+		} else {
+			pdf += " " + key;
+		}
 		pdf = pdf.trim() + ".pdf";
-		return new File(BibtexViewer.PDF_DIR, toURL(pdf));
+		return FileUtils.concat(BibtexViewer.PDF_DIR, toURL(pdf));
 	}
 
 	public String getRelativePDFPath() {
-		return new File(BibtexViewer.PDF_DIR_REL, getPDFPath().getName()).toString();
+		return FileUtils.concat(BibtexViewer.PDF_DIR_REL, getPDFPath().getName()).toString();
 	}
 
 	private String getLastname(String name) {
@@ -336,6 +340,11 @@ public class BibtexEntry {
 	}
 
 	public static boolean isDefined(String attribute) {
-		return attribute != null && !attribute.isEmpty() && !attribute.equals(BibtexEntry.UNKNOWN_ATTRIBUTE) && (!attribute.startsWith("(") || !attribute.endsWith(")"));
+		return
+				attribute != null
+				&& !attribute.isEmpty()
+				&& !attribute.equals(BibtexEntry.UNKNOWN_ATTRIBUTE)
+				&& !attribute.equals(BibtexEntry.EMPTY_ATTRIBUTE)
+				&& (!attribute.startsWith("(") || !attribute.endsWith(")"));
 	}
 }

--- a/MibTeX/src/de/mibtex/FileUtils.java
+++ b/MibTeX/src/de/mibtex/FileUtils.java
@@ -1,0 +1,20 @@
+package de.mibtex;
+
+import java.io.File;
+
+public class FileUtils {
+	public static File concat(File dir, File path) {
+		return concat(dir, path.toString());
+	}
+	
+	public static File concat(File dir, String path) {
+		if (dir.toString().isEmpty()) {
+			return new File(path);
+		}
+		return new File(dir, path);
+	}
+	
+	public static File concat(String dir, String path) {
+		return concat(new File(dir), path);
+	}
+}

--- a/MibTeX/src/de/mibtex/export/Export.java
+++ b/MibTeX/src/de/mibtex/export/Export.java
@@ -40,6 +40,7 @@ import org.jbibtex.ParseException;
 import de.mibtex.BibtexEntry;
 import de.mibtex.BibtexFilter;
 import de.mibtex.BibtexViewer;
+import de.mibtex.FileUtils;
 import de.mibtex.Levenshtein;
 import de.mibtex.citationservice.CitationEntry;
 
@@ -65,7 +66,7 @@ public abstract class Export {
     public Export(String path, String file) throws Exception {
         Reader reader = null;
         try {
-            reader = new FileReader(new File(path, file));
+            reader = new FileReader(FileUtils.concat(path, file));
             BibTeXParser parser = new BibTeXParser() {
                 @Override
                 public void checkStringResolution(Key key, BibTeXString string) {

--- a/MibTeX/src/de/mibtex/export/ExportHTML.java
+++ b/MibTeX/src/de/mibtex/export/ExportHTML.java
@@ -205,13 +205,18 @@ public class ExportHTML extends Export {
 	}
 
 	public static String getHTMLTitle(BibtexEntry entry) {
+		String title = "unspecified"; // for misc entries
+		if (BibtexEntry.isDefined(entry.title)) {
+			title = entry.title;
+		}
+		
 		String htmlTitle = "<a href=\"" + entry.getRelativePDFPath() + "\">";
 		if (entry.getPDFPath().exists()) {
-			 htmlTitle += entry.title + "</a>";
+			htmlTitle += title;
 		} else {
-			htmlTitle = entry.title + " " + htmlTitle + "pdf</a>";
+			htmlTitle = title + " " + htmlTitle + "pdf";
 		}
-		return htmlTitle;
+		return htmlTitle + "</a>";
 	}
 
 	private String getHTMLVenue(BibtexEntry entry) {


### PR DESCRIPTION
Concatenating `java.io.File`s is done by
```java
File parentDir = ...;
new File(parentDir , "relative/path.txt")
```
When parentDir is empty (e.g., `new File("")`), the resulting string will be `/relative/path.txt` whereas we assumed it to be `relative/path.txt` in MibTeX.

This PR introduces a dedicated `FileUtils.concat` method to fix this issue.