### PR TITLE
Solved Issue 25 from our Gitlab

### DIFF
--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -14,8 +14,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
+import org.jbibtex.BibTeXComment;
+import org.jbibtex.BibTeXDatabase;
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.Key;
 import org.jbibtex.Value;
@@ -28,9 +31,9 @@ import de.mibtex.citationservice.CitationEntry;
  * @author Thomas Thuem, Christopher Sontag, Paul Maximilian Bittner
  */
 public class BibtexEntry {
-
 	private static final String UNKNOWN_ATTRIBUTE = "unknown";
 	private static final String EMPTY_ATTRIBUTE = "";
+	private static final Map<String, Integer> MONTH_NAME_TO_NUMBER;
 
 	public List<Key> KEY_LIST = new ArrayList<>();
 	// public static final Key KEY_TT_TAGS = new Key(BibtexViewer.TAGS);
@@ -54,6 +57,22 @@ public class BibtexEntry {
 
 	public int citations = CitationEntry.NOT_IN_CITATION_SERVICE;
 	public long lastUpdate = 0;
+	
+	static {
+		MONTH_NAME_TO_NUMBER = new HashMap<>();
+		MONTH_NAME_TO_NUMBER.put("january", 1);
+		MONTH_NAME_TO_NUMBER.put("february", 2);
+		MONTH_NAME_TO_NUMBER.put("march", 3);
+		MONTH_NAME_TO_NUMBER.put("april", 4);
+		MONTH_NAME_TO_NUMBER.put("may", 5);
+		MONTH_NAME_TO_NUMBER.put("june", 6);
+		MONTH_NAME_TO_NUMBER.put("july", 7);
+		MONTH_NAME_TO_NUMBER.put("august", 8);
+		MONTH_NAME_TO_NUMBER.put("september", 9);
+		MONTH_NAME_TO_NUMBER.put("october", 10);
+		MONTH_NAME_TO_NUMBER.put("november", 11);
+		MONTH_NAME_TO_NUMBER.put("december", 12);
+	}
 
 	public BibtexEntry(BibTeXEntry entry) {
 		for (String tagKey : BibtexViewer.TAGS) {
@@ -260,6 +279,14 @@ public class BibtexEntry {
 	
 	boolean isMisc() {
 		return "misc".equals(type);
+	}
+	
+	public Optional<Integer> getMonthAsNumber() {
+		final String monthName = getAttribute(BibTeXEntry.KEY_MONTH).toLowerCase();
+		if (MONTH_NAME_TO_NUMBER.containsKey(monthName)) {
+			return Optional.of(MONTH_NAME_TO_NUMBER.get(monthName));
+		}
+		return Optional.empty();
 	}
 
 	/**

--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -349,7 +349,7 @@ public class BibtexEntry {
 		replacements.putIfAbsent("&uuml;", "ue");
 		replacements.putIfAbsent("&Auml;", "Ae");
 		replacements.putIfAbsent("&Ouml;", "Oe");
-		replacements.putIfAbsent("�", "O");
+		replacements.putIfAbsent("ï¿½", "O");
 		replacements.putIfAbsent("&Uuml;", "Ue");
 		replacements.putIfAbsent("&szlig;", "ss");
 		replacements.putIfAbsent("&amp;", "and");

--- a/MibTeX/src/de/mibtex/BibtexEntry.java
+++ b/MibTeX/src/de/mibtex/BibtexEntry.java
@@ -99,9 +99,9 @@ public class BibtexEntry {
 		String pdf = "";
 		
 		if (!authorList.isEmpty()) {
-			pdf += getLastname(authorList.get(0));
+			pdf += getLastnameOfFirstAuthor();
 			if (authorList.size() == 2)
-				pdf += " and " + getLastname(authorList.get(1));
+				pdf += " and " + getLastnameOfAuthorNo(1);
 			else if (authorList.size() > 2)
 				pdf += " et al.";
 		}
@@ -124,6 +124,14 @@ public class BibtexEntry {
 
 	private String getLastname(String name) {
 		return name.substring(name.lastIndexOf(" ") + 1);
+	}
+	
+	public String getLastnameOfAuthorNo(int authorIndex) {
+		return getLastname(authorList.get(authorIndex));
+	}
+	
+	public String getLastnameOfFirstAuthor() {
+		return getLastnameOfAuthorNo(0);
 	}
 
 	void parseKey() {

--- a/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
@@ -1,4 +1,4 @@
-package de.mibtex;
+package de.mibtex.clean;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
@@ -20,7 +20,7 @@ public class BibtexCleaner {
 
 	public static void main(String[] args) {
 		attributesToRemove = Arrays.asList(
-				  //"doi",
+				  "doi",
 				  "issn",
 				  "isbn",
 				  "url",

--- a/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A class to remove unnecessary entries from Bibtex files.
@@ -14,8 +16,19 @@ import java.io.IOException;
  * 
  */
 public class BibtexCleaner {
+	private static List<String> attributesToRemove;
 
 	public static void main(String[] args) {
+		attributesToRemove = Arrays.asList(
+				  "doi",
+				  "issn",
+				  "isbn",
+				  "url",
+				  "month",
+				  "location",
+				  "address"
+				);
+		
 		File file = new File(args[0]);
 		processBibtexFile(file);
 	}
@@ -35,9 +48,8 @@ public class BibtexCleaner {
 			BufferedWriter out = new BufferedWriter(new FileWriter(newFile));
 			String line = null;
 			while ((line = in.readLine()) != null) {
-				if (!line.trim().startsWith("doi") && !line.trim().startsWith("issn") && !line.trim().startsWith("isbn")
-						&& !line.trim().startsWith("url") && !line.trim().startsWith("month")
-						&& !line.trim().startsWith("location") && !line.trim().startsWith("address")) {
+				String trimmedLine = line.trim();
+				if (attributesToRemove.stream().noneMatch(trimmedLine::startsWith)) {
 					out.write(line + "\r\n");
 				}
 			}

--- a/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
@@ -20,7 +20,7 @@ public class BibtexCleaner {
 
 	public static void main(String[] args) {
 		attributesToRemove = Arrays.asList(
-				  "doi",
+				  //"doi",
 				  "issn",
 				  "isbn",
 				  "url",

--- a/MibTeX/src/de/mibtex/clean/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/clean/LatexPublisher.java
@@ -79,7 +79,6 @@ public class LatexPublisher {
 			if (keepPDFs) {
 				BLACKLISTED_FILE_ENDINGS.remove(".pdf");
 			} else {
-
 				BLACKLISTED_FILE_ENDINGS.add(".pdf");
 			}
 			
@@ -191,14 +190,10 @@ public class LatexPublisher {
 	 */
 	private static boolean isDocumentationComment(String line, int commentBeginIndex) {
 		final int charactersAfterBeginIndex = line.length() - 1 - commentBeginIndex;
-		final boolean isDocsComment = charactersAfterBeginIndex >= 2
+		return charactersAfterBeginIndex >= 2
 				&& COMMENT_BEGIN == line.charAt(commentBeginIndex)
 				&& COMMENT_BEGIN == line.charAt(commentBeginIndex + 1)
 				&& COMMENT_BEGIN == line.charAt(commentBeginIndex + 2);
-		//System.out.println("  isDocumentationComment(\"" + line + "\", " + commentBeginIndex + ")");
-		//System.out.println("= isDocumentationComment(" + line.substring(commentBeginIndex) + ")");
-		//System.out.println("= " + isDocsComment);
-		return isDocsComment;
 	}
 	
 	private static String putInQuotes(String s) {

--- a/MibTeX/src/de/mibtex/clean/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/clean/LatexPublisher.java
@@ -1,0 +1,76 @@
+package de.mibtex.clean;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * A class to prepare LaTeX documents for publishing. It removes all generated files and comments.
+ * 
+ * @author Thomas Thuem
+ * 
+ */
+public class LatexPublisher {
+
+	public static void main(String[] args) {
+		File dir = new File("C:\\Users\\tthuem\\Desktop\\tex");
+		processDirectory(dir);
+	}
+
+	private static void processDirectory(File dir) {
+		for (File file : dir.listFiles()) {
+			if (file.getName().equals(".svn")
+					|| file.getName().endsWith(".pdf")
+					|| file.getName().endsWith(".toc")
+					|| file.getName().endsWith(".tps")
+					|| file.getName().endsWith(".tcp")
+					|| file.getName().endsWith(".aux")
+					|| file.getName().endsWith(".out")
+					|| file.getName().endsWith(".bbl")
+					|| file.getName().endsWith(".blg")
+					|| file.getName().endsWith(".synctex")
+					|| file.getName().endsWith(".log")) {
+				if (file.delete())
+					System.out.println(file + " deleted");
+				else
+					System.err.println(file + " could not be deleted");
+			} else if (file.isDirectory())
+				processDirectory(file);
+			else if (file.getName().endsWith(".tex"))
+				processLatexFile(file);
+		}
+	}
+
+	private static void processLatexFile(File file) {
+		File temp = new File(file + "~");
+		file.renameTo(temp);
+		try {
+			BufferedReader in = new BufferedReader(new FileReader(temp));
+			BufferedWriter out = new BufferedWriter(new FileWriter(file));
+			String line = null;
+			while ((line = in.readLine()) != null) {
+				int pos = line.indexOf('%');
+				while (pos > 0 && line.charAt(pos - 1) == '\\')
+					pos = line.indexOf('%', pos + 1);
+				if (pos < 0)
+					out.write(line + "\r\n");
+				else {
+					// System.out.print(line + " > ");
+					line = line.substring(0, line.indexOf("%") + 1);
+					// System.out.println(line);
+					out.write(line + "\r\n");
+				}
+			}
+			out.close();
+			in.close();
+			temp.delete();
+			System.out.println(file + " processed");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/MibTeX/src/de/mibtex/clean/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/clean/LatexPublisher.java
@@ -18,6 +18,7 @@ import java.util.List;
  */
 public class LatexPublisher {
 	private final static char COMMENT_BEGIN = '%';
+	private static boolean allowDocsComments = true;
 	
 	private static class Blacklists {
 		/// Wrap in ArrayList to make mutable. Otherwise the list is immutable.
@@ -48,15 +49,25 @@ public class LatexPublisher {
 		}
 	}
 	
-	private static void jankyBlackListUpdateForFTR() {
+	private static void activateProjectSpecificSettingsBecauseIAmToLazyToWriteAnArgumentParser() {
+		// ACM requires the .bbl file
 		Blacklists.FILE_ENDINGS.removeAll(Arrays.asList(
-				".pdf",
 				".bbl"
 				));
-		Blacklists.FILE_ENDINGS.addAll(Arrays.asList(
-				".sh",
-				".bat"
-				));
+		
+		// Set to true if comments starting with %%% should remain in the tex files.
+		allowDocsComments = true;
+		
+		/* Feature Trace Recording
+		{
+			Blacklists.FILE_ENDINGS.removeAll(Arrays.asList(
+					".bbl"
+					));
+			Blacklists.FILE_ENDINGS.addAll(Arrays.asList(
+					".sh",
+					".bat"
+					));
+		}//*/
 	}
 	
 	public static void main(String[] args) {
@@ -65,7 +76,7 @@ public class LatexPublisher {
 			return;
 		}
 		
-		jankyBlackListUpdateForFTR();
+		activateProjectSpecificSettingsBecauseIAmToLazyToWriteAnArgumentParser();
 		
 		processDirectory(new File(args[0]));
 	}
@@ -109,9 +120,9 @@ public class LatexPublisher {
 				
 				/// Keep the entire line if there is no comment or if the comment
 				/// is for documentation purposes.
-				if (pos < 0 || isDocumentationComment(line, pos))
+				if (pos < 0 || (allowDocsComments && isDocumentationComment(line, pos))) {
 					out.write(line + "\r\n");
-				else {
+				} else {
 					//System.out.print(putInQuotes(line) + " with pos = " + pos + " > ");
 					line = line.substring(0, pos).trim();
 					//System.out.println(putInQuotes(line));

--- a/MibTeX/src/de/mibtex/clean/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/clean/LatexPublisher.java
@@ -1,3 +1,9 @@
+/* MibTeX - Minimalistic tool to manage your references with BibTeX
+ * 
+ * Distributed under BSD 3-Clause License, available at Github
+ * 
+ * https://github.com/tthuem/MibTeX
+ */
 package de.mibtex.clean;
 
 import java.io.BufferedReader;

--- a/MibTeX/src/de/mibtex/clean/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/clean/LatexPublisher.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A class to prepare LaTeX documents for publishing. It removes all generated files and comments.
@@ -14,52 +16,83 @@ import java.io.IOException;
  * 
  */
 public class LatexPublisher {
-
+	private final static char COMMENT_BEGIN = '%';
+	
+	private static class Blacklists {
+		final static List<String> FILES = Arrays.asList(
+				".svn"
+				);
+	
+		final static List<String> FILE_ENDINGS = Arrays.asList(
+				".pdf",
+				".toc",
+				".tps",
+				".tcp",
+				".aux",
+				".out",
+				//".bbl", // required by ACM
+				".blg",
+				".synctex",
+				".log"
+				);
+		static {
+			assert !FILE_ENDINGS.contains(".tex");
+		}
+		
+		static boolean isBlackListed(String filename) {
+			return FILES.stream().anyMatch(filename::equals)
+					|| FILE_ENDINGS.stream().anyMatch(filename::endsWith);
+		}
+	}
+	
 	public static void main(String[] args) {
-		File dir = new File("C:\\Users\\tthuem\\Desktop\\tex");
-		processDirectory(dir);
+		if (args.length != 1) {
+			System.err.println("Expected exactly 1 argument: Path to latex project.");
+			return;
+		}
+		
+		processDirectory(new File(args[0]));
 	}
 
 	private static void processDirectory(File dir) {
 		for (File file : dir.listFiles()) {
-			if (file.getName().equals(".svn")
-					|| file.getName().endsWith(".pdf")
-					|| file.getName().endsWith(".toc")
-					|| file.getName().endsWith(".tps")
-					|| file.getName().endsWith(".tcp")
-					|| file.getName().endsWith(".aux")
-					|| file.getName().endsWith(".out")
-					|| file.getName().endsWith(".bbl")
-					|| file.getName().endsWith(".blg")
-					|| file.getName().endsWith(".synctex")
-					|| file.getName().endsWith(".log")) {
-				if (file.delete())
-					System.out.println(file + " deleted");
-				else
-					System.err.println(file + " could not be deleted");
-			} else if (file.isDirectory())
+			if (Blacklists.isBlackListed(file.getName())) {
+				if (file.delete()) {
+					System.out.println(file + " deleted.");
+				} else {
+					System.err.println(file + " could not be deleted!");
+				}
+			} else if (file.isDirectory()) {
 				processDirectory(file);
-			else if (file.getName().endsWith(".tex"))
+			} else if (file.getName().endsWith(".tex")) {
 				processLatexFile(file);
+			}
 		}
 	}
 
 	private static void processLatexFile(File file) {
-		File temp = new File(file + "~");
+		final File temp = new File(file + "~");
 		file.renameTo(temp);
 		try {
-			BufferedReader in = new BufferedReader(new FileReader(temp));
-			BufferedWriter out = new BufferedWriter(new FileWriter(file));
+			final BufferedReader in = new BufferedReader(new FileReader(temp));
+			final BufferedWriter out = new BufferedWriter(new FileWriter(file));
+			
 			String line = null;
 			while ((line = in.readLine()) != null) {
-				int pos = line.indexOf('%');
-				while (pos > 0 && line.charAt(pos - 1) == '\\')
-					pos = line.indexOf('%', pos + 1);
-				if (pos < 0)
+				/// Find begin of inline comment.
+				int pos = line.indexOf(COMMENT_BEGIN);
+				/// Skip all usages of the percent sign itself (\%) as these do not denote comments.
+				while (pos > 0 && line.charAt(pos - 1) == '\\') {
+					pos = line.indexOf(COMMENT_BEGIN, pos + 1);
+				}
+				
+				/// Keep the entire line if there is no comment or if the comment
+				/// is for documentation purposes.
+				if (pos < 0 || isDocumentationComment(line, pos))
 					out.write(line + "\r\n");
 				else {
 					// System.out.print(line + " > ");
-					line = line.substring(0, line.indexOf("%") + 1);
+					line = line.substring(0, line.indexOf(COMMENT_BEGIN) + 1);
 					// System.out.println(line);
 					out.write(line + "\r\n");
 				}
@@ -67,10 +100,20 @@ public class LatexPublisher {
 			out.close();
 			in.close();
 			temp.delete();
-			System.out.println(file + " processed");
+			System.out.println(file + " processed.");
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
+	/**
+	 * @return True iff the comment at commentBeginIndex in line starts with "%%%".
+	 */
+	private static boolean isDocumentationComment(String line, int commentBeginIndex) {
+		final int charactersAfterBeginIndex = line.length() - 1 - commentBeginIndex;
+		return charactersAfterBeginIndex > 2
+				&& COMMENT_BEGIN == line.charAt(commentBeginIndex)
+				&& COMMENT_BEGIN == line.charAt(commentBeginIndex + 1)
+				&& COMMENT_BEGIN == line.charAt(commentBeginIndex + 2);
+	}
 }

--- a/MibTeX/src/de/mibtex/export/ExportHTML.java
+++ b/MibTeX/src/de/mibtex/export/ExportHTML.java
@@ -214,6 +214,7 @@ public class ExportHTML extends Export {
 		if (entry.getPDFPath().exists()) {
 			htmlTitle += title;
 		} else {
+			System.out.println("Entry \"" + entry.getPDFPath() + "\" does not exist!");
 			htmlTitle = title + " " + htmlTitle + "pdf";
 		}
 		return htmlTitle + "</a>";

--- a/MibTeX/src/de/mibtex/export/ExportHTML.java
+++ b/MibTeX/src/de/mibtex/export/ExportHTML.java
@@ -214,7 +214,7 @@ public class ExportHTML extends Export {
 		if (entry.getPDFPath().exists()) {
 			htmlTitle += title;
 		} else {
-			System.out.println("Entry \"" + entry.getPDFPath() + "\" does not exist!");
+			//System.out.println("Entry \"" + entry.getPDFPath() + "\" does not exist!");
 			htmlTitle = title + " " + htmlTitle + "pdf";
 		}
 		return htmlTitle + "</a>";

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -55,7 +55,8 @@ public class ExportTypo3Bibtex extends Export {
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
 			//Filters.ANY,
-			Filters.keyIsOneOf("Y21", "YWT:SPLC20")
+			//Filters.keyIsOneOf("Y21", "YWT:SPLC20")
+			Filters.keyIsOneOf("HST:SPLC21")
 			//Filters.BELONGS_TO_SOFTVARE
 			//Filters.WithThomasAtUlm
 			//Filters.Any()

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -54,35 +54,9 @@ public class ExportTypo3Bibtex extends Export {
 	 * Compose filters with the respective methods of Predicate<T> (such as `and`, `or`).
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
-			Filters.keyIsOneOf(
-					"DGT:EMSE21",
-					"KTSB:ICSE21",
-					"BST+:ESECFSE21",
-					"KAN+:SPLC21",
-					"SFE+:SPLC21",
-					"PKT+:SPLC21",
-					"NST+:SoSyM21",
-					"KTS:FormaliSE21",
-					"RSC+:SE21",
-					"KJN+:SE21",
-					"PKR+:VaMoS21",
-					"HPTS:VaMoS21",
-					"SNB+:VaMoS21",
-					"KKT+20",
-					"useNST+:SoSyM21",
-					"YWT:SPLC20",
-					"SBKT:SPLC20",
-					"T:SPLC20",
-					"RKTS:FormaliSE20",
-					"RTC+:REFINE20",
-					"KJN+:FASE20",
-					"KTS+:VaMoS20",
-					"BRK+:VaMoS20",
-					"SSK+:VaMoS20",
-					"STS:VaMoS20")
 			//Filters.ANY,
 			//Filters.keyIsOneOf("BST+:ESECFSE21")
-			//Filters.BELONGS_TO_SOFTVARE
+			Filters.BELONGS_TO_SOFTVARE
 			//Filters.WithThomasAtUlm
 			//Filters.Any()
 			//Filters.keyIsOneOf("KTSB:ICSE21")
@@ -104,7 +78,7 @@ public class ExportTypo3Bibtex extends Export {
 	private final List<Function<Typo3Entry, Typo3Entry>> modifiers = Arrays.asList(
 			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
-			//, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
+			, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
 			, Modifiers.whenKeyIs("DGT:EMSE21", Modifiers.MARK_THOMAS_AS_EDITOR)
 
 			// Resolving duplicates

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -55,8 +55,8 @@ public class ExportTypo3Bibtex extends Export {
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
 			//Filters.ANY,
-			//Filters.keyIsOneOf("BST+:ESECFSE21")
-			Filters.BELONGS_TO_SOFTVARE
+			Filters.keyIsOneOf("Y21", "YWT:SPLC20")
+			//Filters.BELONGS_TO_SOFTVARE
 			//Filters.WithThomasAtUlm
 			//Filters.Any()
 			//Filters.keyIsOneOf("KTSB:ICSE21")
@@ -82,8 +82,10 @@ public class ExportTypo3Bibtex extends Export {
 			
 			// Custom solutions
 			, Modifiers.whenKeyIs("DGT:EMSE21", Modifiers.MARK_THOMAS_AS_EDITOR)
+			, Modifiers.whenKeyIs("Y21", Modifiers.KEEP_URL_IF_PRESENT)
 
 			// Resolving duplicates
+			, Modifiers.whenKeyIs("Y21", Modifiers.MARK_AS_PHDTHESIS)
 			, Modifiers.whenKeyIs("KJN+:SE21", Modifiers.MARK_AS_EXTENDED_ABSTRACT)
 			, Modifiers.whenKeyIs("RSC+:SE21", Modifiers.MARK_AS_EXTENDED_ABSTRACT)
 			, Modifiers.whenKeyIs("TKK+:SPLC19", Modifiers.MARK_AS_EXTENDED_ABSTRACT)

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -54,8 +54,8 @@ public class ExportTypo3Bibtex extends Export {
 	 * Compose filters with the respective methods of Predicate<T> (such as `and`, `or`).
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
-			Filters.ANY
-			//Filters.keyIsOneOf("KTSB:ICSE21")
+			//Filters.ANY,
+			Filters.keyIsOneOf("BST+:ESECFSE21")
 			//Filters.WithThomasAtUlm
 			//Filters.Any()
 			//Filters.keyIsOneOf("KTSB:ICSE21")

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -79,6 +79,8 @@ public class ExportTypo3Bibtex extends Export {
 			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
 			, Modifiers.ADD_PAPER_LINK_IF_SOFTVARE
+			
+			// Custom solutions
 			, Modifiers.whenKeyIs("DGT:EMSE21", Modifiers.MARK_THOMAS_AS_EDITOR)
 
 			// Resolving duplicates

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -77,6 +77,7 @@ public class ExportTypo3Bibtex extends Export {
 	private final List<Function<Typo3Entry, Typo3Entry>> modifiers = Arrays.asList(
 			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
+			, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
 
 			// Resolving duplicates
 			, Modifiers.whenKeyIs("KJN+:SE21", Modifiers.MARK_AS_EXTENDED_ABSTRACT)
@@ -97,17 +98,17 @@ public class ExportTypo3Bibtex extends Export {
 	@Override
 	public void writeDocument() {
 		// Parse the variables defined in MYabrv.bib
-		Map<String, String> variables = readVariablesFromBibtexFile(new File(BibtexViewer.BIBTEX_DIR, VariablesFile));
+		final Map<String, String> variables = readVariablesFromBibtexFile(new File(BibtexViewer.BIBTEX_DIR, VariablesFile));
 
 		// Transform all Bibtex-Entries to Typo3Entries, filter them and apply all modifiers.
-		List<Typo3Entry> typo3Entries = entries.values().stream()
+		final List<Typo3Entry> typo3Entries = entries.values().stream()
 				.map(b -> new Typo3Entry(b, variables))
 				.filter(bibFilter)
 				.map(modifiers.stream().reduce(Function.identity(), Function::compose))
 				.collect(Collectors.toList());
 
 		// Generate the typo3-conforming Bibtex source code.
-		String typo3 = typo3Entries.stream()
+		final String typo3 = typo3Entries.stream()
 				.map(Typo3Entry::toString)
 				.reduce("", (a, b) -> a + "\n\n" + b);
 
@@ -115,7 +116,7 @@ public class ExportTypo3Bibtex extends Export {
 		System.out.println();
 
 		// Check if we have some duplicates left that were not resolved.
-		int duplicates = Util.getDuplicates(typo3Entries, (a, b) -> System.out.println("  > Found unresolved duplicate: " + a.title));
+		final int duplicates = Util.getDuplicates(typo3Entries, (a, b) -> System.out.println("  > Found unresolved duplicate: " + a.title));
 		final long numUniqueEntries = typo3Entries.size() - duplicates;
 
 		System.out.println("\nExported " + typo3Entries.size() + " entries.");
@@ -131,9 +132,9 @@ public class ExportTypo3Bibtex extends Export {
 	}
 
 	private static Map<String, String> readVariablesFromBibtexFile(File pathToBibtex) {
-		Map<String, String> vars = new HashMap<String, String>();
+		final Map<String, String> vars = new HashMap<String, String>();
 
-		BufferedReader file = readFromFile(pathToBibtex, Charset.forName("UTF-8"));
+		final BufferedReader file = readFromFile(pathToBibtex, Charset.forName("UTF-8"));
 		try {
 			while (file.ready()) {
 				String line = file.readLine().trim();
@@ -152,6 +153,12 @@ public class ExportTypo3Bibtex extends Export {
 			file.close();
 		} catch (IOException e) {
 			e.printStackTrace();
+		} finally {
+			try {
+				file.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 		}
 
 		return vars;

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -54,9 +54,35 @@ public class ExportTypo3Bibtex extends Export {
 	 * Compose filters with the respective methods of Predicate<T> (such as `and`, `or`).
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
+			Filters.keyIsOneOf(
+					"DGT:EMSE21",
+					"KTSB:ICSE21",
+					"BST+:ESECFSE21",
+					"KAN+:SPLC21",
+					"SFE+:SPLC21",
+					"PKT+:SPLC21",
+					"NST+:SoSyM21",
+					"KTS:FormaliSE21",
+					"RSC+:SE21",
+					"KJN+:SE21",
+					"PKR+:VaMoS21",
+					"HPTS:VaMoS21",
+					"SNB+:VaMoS21",
+					"KKT+20",
+					"useNST+:SoSyM21",
+					"YWT:SPLC20",
+					"SBKT:SPLC20",
+					"T:SPLC20",
+					"RKTS:FormaliSE20",
+					"RTC+:REFINE20",
+					"KJN+:FASE20",
+					"KTS+:VaMoS20",
+					"BRK+:VaMoS20",
+					"SSK+:VaMoS20",
+					"STS:VaMoS20")
 			//Filters.ANY,
 			//Filters.keyIsOneOf("BST+:ESECFSE21")
-			Filters.BELONGS_TO_SOFTVARE
+			//Filters.BELONGS_TO_SOFTVARE
 			//Filters.WithThomasAtUlm
 			//Filters.Any()
 			//Filters.keyIsOneOf("KTSB:ICSE21")
@@ -78,7 +104,8 @@ public class ExportTypo3Bibtex extends Export {
 	private final List<Function<Typo3Entry, Typo3Entry>> modifiers = Arrays.asList(
 			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
-			, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
+			//, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
+			, Modifiers.whenKeyIs("DGT:EMSE21", Modifiers.MARK_THOMAS_AS_EDITOR)
 
 			// Resolving duplicates
 			, Modifiers.whenKeyIs("KJN+:SE21", Modifiers.MARK_AS_EXTENDED_ABSTRACT)

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -78,7 +78,7 @@ public class ExportTypo3Bibtex extends Export {
 	private final List<Function<Typo3Entry, Typo3Entry>> modifiers = Arrays.asList(
 			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
-			, Modifiers.ADD_PAPER_LINK_IF_SOFVARE
+			, Modifiers.ADD_PAPER_LINK_IF_SOFTVARE
 			, Modifiers.whenKeyIs("DGT:EMSE21", Modifiers.MARK_THOMAS_AS_EDITOR)
 
 			// Resolving duplicates

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -55,7 +55,8 @@ public class ExportTypo3Bibtex extends Export {
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
 			//Filters.ANY,
-			Filters.keyIsOneOf("BST+:ESECFSE21")
+			//Filters.keyIsOneOf("BST+:ESECFSE21")
+			Filters.BELONGS_TO_SOFTVARE
 			//Filters.WithThomasAtUlm
 			//Filters.Any()
 			//Filters.keyIsOneOf("KTSB:ICSE21")

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -53,10 +53,11 @@ public class ExportTypo3Bibtex extends Export {
 	 * For instance, if you want to select a subset of specific publications manually, use
 	 *     Filters.KeyIsOneOf("Key1", "Key2", ...)
 	 * to select all publications with these keys.
+	 * Compose filters with the respective methods of Predicate<T> (such as `and`, `or`).
 	 */
 	private final Predicate<Typo3Entry> bibFilter =
-			//Filters.Any()
-			Filters.keyIsOneOf("KTSB:ICSE21")
+			Filters.ANY
+			//Filters.keyIsOneOf("KTSB:ICSE21")
 			//Filters.WithThomasAtUlm
 			//Filters.WithPaulAtUlm
 			//Filters.WithPaulBeforeOrNotAtUlm
@@ -74,7 +75,7 @@ public class ExportTypo3Bibtex extends Export {
 	 * If unsure, leave unchanged.
 	 */
 	private final List<Function<Typo3Entry, Typo3Entry>> modifiers = Arrays.asList(
-			Modifiers.MARK_IF_THOMAS_IS_EDITOR
+			  Modifiers.MARK_IF_THOMAS_IS_EDITOR
 			, Modifiers.MARK_IF_TO_APPEAR
 
 			// Resolving duplicates

--- a/MibTeX/src/de/mibtex/export/typo3/Filters.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Filters.java
@@ -23,6 +23,8 @@ public class Filters {
 	public final static String TOBIAS_HESS = "Tobias Heﬂ";
 	public final static String PAUL_MAXIMILIAN_BITTNER = "Paul Maximilian Bittner";
 	
+	public final static Predicate<Typo3Entry> ANY = b -> true;
+	
 	public final static Predicate<Typo3Entry> IS_MISC = b -> b.type.equals("misc");
 	public final static Predicate<Typo3Entry> IS_PROCEEDINGS = b -> b.type.equals("proceedings");
 	public final static Predicate<Typo3Entry> IS_TECHREPORT = b -> b.type.equals("techreport");

--- a/MibTeX/src/de/mibtex/export/typo3/Filters.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Filters.java
@@ -49,7 +49,10 @@ public class Filters {
 			.and(t -> t.year >= 2020);
 	public final static Predicate<Typo3Entry> WITH_PAUL_BEFORE_OR_NOT_AT_ULM = WITH_PAUL.and(WITH_PAUL_AT_ULM.negate());
 
-	public final static Predicate<Typo3Entry> BELONGS_TO_SOFTVARE = Filters.authorOrEditorIsOneOf(THOMAS_THUEM, CHICO_SUNDERMANN, TOBIAS_HESS, PAUL_MAXIMILIAN_BITTNER).and(b -> b.year >= 2020);
+	public final static Predicate<Typo3Entry> BELONGS_TO_SOFTVARE = Filters
+			.authorOrEditorIsOneOf(THOMAS_THUEM, CHICO_SUNDERMANN, TOBIAS_HESS, PAUL_MAXIMILIAN_BITTNER)
+			.and(WITH_PAUL_AT_ICG.negate())
+			.and(b -> b.year >= 2020);
 
 	public final static Predicate<Typo3Entry> BELONGS_TO_VARIANTSYNC = b -> {
 		if (b.tags == null) return false;

--- a/MibTeX/src/de/mibtex/export/typo3/Filters.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Filters.java
@@ -51,6 +51,7 @@ public class Filters {
 
 	public final static Predicate<Typo3Entry> BELONGS_TO_SOFTVARE = Filters
 			.authorOrEditorIsOneOf(THOMAS_THUEM, CHICO_SUNDERMANN, TOBIAS_HESS, PAUL_MAXIMILIAN_BITTNER)
+			.and(IS_MASTERSTHESIS.negate())
 			.and(WITH_PAUL_AT_ICG.negate())
 			.and(b -> b.year >= 2020);
 

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -16,11 +16,18 @@ import java.util.function.Function;
  * @author Paul Maximilian Bittner
  */
 public class Modifiers {
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_THOMAS_IS_EDITOR = Util.when(t -> t.editors.contains(Filters.THOMAS_THUEM), addTag("EditorialThomasThuem"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE = Util.when(t -> "SE".equals(t.source.venue), appendToTitle("(SE)"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR = Util.when(t -> t.note.toLowerCase().contains("to appear"), appendToBookTitle("(To Appear)"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TECHREPORT = Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");
-	public static Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT = appendToTitle("(Extended Abstract)");
+	public static Function<Typo3Entry, Typo3Entry> MARK_IF_THOMAS_IS_EDITOR =
+			Util.when(t -> t.editors.contains(Filters.THOMAS_THUEM), addTag("EditorialThomasThuem"));
+	public static Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE =
+			Util.when(t -> "SE".equals(t.source.venue), appendToTitle("(SE)"));
+	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR =
+			Util.when(t -> t.note.toLowerCase().contains("to appear"), appendToBookTitle("(To Appear)"));
+	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TECHREPORT =
+			Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");
+	public static Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT =
+			appendToTitle("(Extended Abstract)");
+	public static Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFVARE = 
+			Util.when(Filters.BELONGS_TO_SOFTVARE, setSoftVarEURL());
 	
 	public static Function<Typo3Entry, Typo3Entry> appendToTitle(String suffix) {
 		return t -> {
@@ -39,6 +46,20 @@ public class Modifiers {
 	public static Function<Typo3Entry, Typo3Entry> addTag(String tag) {
 		return t -> {
 			t.tags.add(tag);
+			return t;
+		};
+	}
+	
+	public static Function<Typo3Entry, Typo3Entry> setSoftVarEURL() {
+		return t -> {
+			t.url = t.getPaperUrlInSoftVarERepo();
+			return t;
+		};
+	}
+	
+	public static Function<Typo3Entry, Typo3Entry> setURL(String url) {
+		return t -> {
+			t.url = url;
 			return t;
 		};
 	}

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -16,8 +16,10 @@ import java.util.function.Function;
  * @author Paul Maximilian Bittner
  */
 public class Modifiers {
+	public static final Function<Typo3Entry, Typo3Entry> MARK_THOMAS_AS_EDITOR =
+			addTag("EditorialThomasThuem");
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_THOMAS_IS_EDITOR =
-			Util.when(t -> t.editors.contains(Filters.THOMAS_THUEM), addTag("EditorialThomasThuem"));
+			Util.when(t -> t.editors.contains(Filters.THOMAS_THUEM), MARK_THOMAS_AS_EDITOR);
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE =
 			Util.when(t -> "SE".equals(t.source.venue), appendToTitle("(SE)"));
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR =

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -16,17 +16,18 @@ import java.util.function.Function;
  * @author Paul Maximilian Bittner
  */
 public class Modifiers {
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_THOMAS_IS_EDITOR =
+	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_THOMAS_IS_EDITOR =
 			Util.when(t -> t.editors.contains(Filters.THOMAS_THUEM), addTag("EditorialThomasThuem"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE =
+	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE =
 			Util.when(t -> "SE".equals(t.source.venue), appendToTitle("(SE)"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR =
-			Util.when(t -> t.note.toLowerCase().contains("to appear"), appendToBookTitle("(To Appear)"));
-	public static Function<Typo3Entry, Typo3Entry> MARK_IF_TECHREPORT =
+	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR =
+			// TODO: appendToBookTitle if inproceedings but append to journal if journal!
+			Util.when(t -> t.note.toLowerCase().contains("to appear"), appendToVenue("(To Appear)"));
+	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_TECHREPORT =
 			Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");
-	public static Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT =
+	public static final Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT =
 			appendToTitle("(Extended Abstract)");
-	public static Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFVARE = 
+	public static final Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFVARE = 
 			Util.when(Filters.BELONGS_TO_SOFTVARE, setSoftVarEURL());
 	
 	public static Function<Typo3Entry, Typo3Entry> appendToTitle(String suffix) {
@@ -36,9 +37,13 @@ public class Modifiers {
 		};
 	}
 	
-	public static Function<Typo3Entry, Typo3Entry> appendToBookTitle(String suffix) {
+	public static Function<Typo3Entry, Typo3Entry> appendToVenue(String suffix) {
 		return t -> {
-			t.booktitle += " " + suffix;
+			if (t.isJournalPaper()) {
+				t.journal += " " + suffix;
+			} else {
+				t.booktitle += " " + suffix;
+			}
 			return t;
 		};
 	} 
@@ -53,13 +58,6 @@ public class Modifiers {
 	public static Function<Typo3Entry, Typo3Entry> setSoftVarEURL() {
 		return t -> {
 			t.url = t.getPaperUrlInSoftVarERepo();
-			return t;
-		};
-	}
-	
-	public static Function<Typo3Entry, Typo3Entry> setURL(String url) {
-		return t -> {
-			t.url = url;
 			return t;
 		};
 	}

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -7,6 +7,9 @@
 package de.mibtex.export.typo3;
 
 import java.util.function.Function;
+import org.jbibtex.BibTeXEntry;
+
+import de.mibtex.BibtexEntry;
 
 /**
  * This is a collection of default modifiers to use for the ExportTypo3Bibtex.
@@ -28,8 +31,18 @@ public class Modifiers {
 			Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");
 	public static final Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT =
 			appendToTitle("(Extended Abstract)");
+	public static final Function<Typo3Entry, Typo3Entry> MARK_AS_PHDTHESIS =
+			appendToTitle("(PhD Thesis)");
 	public static final Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFTVARE = 
 			Util.when(Filters.BELONGS_TO_SOFTVARE, setSoftVarEURL());
+	public static final Function<Typo3Entry, Typo3Entry> KEEP_URL_IF_PRESENT =
+			t -> {
+				final String url = t.source.getAttribute("url");
+				if (BibtexEntry.isDefined(url)) {
+					t.url = url;
+				}
+				return t;
+			};
 	
 	public static Function<Typo3Entry, Typo3Entry> appendToTitle(String suffix) {
 		return t -> {

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -28,7 +28,7 @@ public class Modifiers {
 			Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");
 	public static final Function<Typo3Entry, Typo3Entry> MARK_AS_EXTENDED_ABSTRACT =
 			appendToTitle("(Extended Abstract)");
-	public static final Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFVARE = 
+	public static final Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFTVARE = 
 			Util.when(Filters.BELONGS_TO_SOFTVARE, setSoftVarEURL());
 	
 	public static Function<Typo3Entry, Typo3Entry> appendToTitle(String suffix) {

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -21,7 +21,6 @@ public class Modifiers {
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_VENUE_IS_SE =
 			Util.when(t -> "SE".equals(t.source.venue), appendToTitle("(SE)"));
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_TO_APPEAR =
-			// TODO: appendToBookTitle if inproceedings but append to journal if journal!
 			Util.when(t -> t.note.toLowerCase().contains("to appear"), appendToVenue("(To Appear)"));
 	public static final Function<Typo3Entry, Typo3Entry> MARK_IF_TECHREPORT =
 			Util.whenForced(Filters.IS_TECHREPORT, appendToTitle("(Technical Report)"), "Given entry is not a technical report! (Perhaps an illegal modifier?)");

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -71,8 +71,8 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	
 	public List<String> tags;
 	
-	// Not set automatically, only with modifiers
-	public String url;
+	/// Empty by default. We only set the URL via modifiers as we have no general policy for where and how to get URLs.
+	public String url = "";
 	
 	public Typo3Entry(BibtexEntry bib, Map<String, String> variables) {
 		this.source = bib;
@@ -175,6 +175,10 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 				persons.stream()
 				.reduce((a, b) -> a + " and " + b)
 				.orElseGet(() -> {throw new IllegalArgumentException("Person list is empty!");}));
+	}
+	
+	public boolean isJournalPaper() {
+		return BibtexEntry.isDefined(journal);
 	}
 	
 	@Override

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -138,6 +138,8 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		} else if (!editors.isEmpty()) {
 			persons = editors;
 			personType = "editor";
+		} else if (Filters.IS_MISC.test(this)) {
+			return "";
 		} else {
 			throw new RuntimeException("The Typo3Entry with key " + this.key + " has neither authors nor editors!");
 		}

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -29,18 +29,18 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	private static final String PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
-		TO_URL_OVERWRITES.put("&auml;", "ä");
-		TO_URL_OVERWRITES.put("&ouml;", "ö");
-		TO_URL_OVERWRITES.put("&uuml;", "ü");
-		TO_URL_OVERWRITES.put("&Auml;", "Ä");
-		TO_URL_OVERWRITES.put("&Ouml;", "Ö");
-		TO_URL_OVERWRITES.put("&Uuml;", "Ü");
+		TO_URL_OVERWRITES.put("&auml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&ouml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&uuml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&Auml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&Ouml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&Uuml;", "ï¿½");
 		TO_URL_OVERWRITES.put("&8211;", "-");
 		TO_URL_OVERWRITES.put("?", "?");
 		TO_URL_OVERWRITES.put(":", ":");
 		TO_URL_OVERWRITES.put("/", "/");
 		TO_URL_OVERWRITES.put("#", "#");
-		TO_URL_OVERWRITES.put("&szlig;", "ß");
+		TO_URL_OVERWRITES.put("&szlig;", "ï¿½");
 	}
 	
 	public final BibtexEntry source;
@@ -112,27 +112,30 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 
 	@Override
 	public String toString() {
-		String typo3 = "@" + type + "{" + key;
+		final StringBuilder typo3 = new StringBuilder();
+		typo3.append("@").append(type).append("{").append(key);
 
-		typo3 += genBibTeXAttributeIfPresent("type", this.typeAttrib);
-		typo3 += genAuthorList();
-		typo3 += genBibTeXAttributeIfPresent("title", title);
-		typo3 += genBibTeXAttributeIfPresent("year", Integer.toString(year));
-		typo3 += genBibTeXAttributeIfPresent("month", month);
-		typo3 += genBibTeXAttributeIfPresent("booktitle", booktitle);
-		typo3 += genBibTeXAttributeIfPresent("address", address);
-		typo3 += genBibTeXAttributeIfPresent("publisher", publisher);
-		typo3 += genBibTeXAttributeIfPresent("journal", journal);
-		typo3 += genBibTeXAttributeIfPresent("location", location);
-		typo3 += genBibTeXAttributeIfPresent("school", school);
-		typo3 += genBibTeXAttributeIfPresent("pages", pages);
-		typo3 += genBibTeXAttributeIfPresent("doi", doi);
-		typo3 += genBibTeXAttributeIfPresent("isbn", isbn);
-		typo3 += genBibTeXAttributeIfPresent("issn", issn);
-		typo3 += genBibTeXAttributeIfPresent("note", note);
-		typo3 += genBibTeXAttributeIfPresent("tags", tags.stream().reduce((a, b) -> a + ", " + b).orElseGet(() -> ""));
+		typo3.append(genBibTeXAttributeIfPresent("type", this.typeAttrib));
+		typo3.append(genAuthorList());
+		typo3.append(genBibTeXAttributeIfPresent("title", title));
+		typo3.append(genBibTeXAttributeIfPresent("year", Integer.toString(year)));
+		typo3.append(genBibTeXAttributeIfPresent("month", month));
+		typo3.append(genBibTeXAttributeIfPresent("booktitle", booktitle));
+		typo3.append(genBibTeXAttributeIfPresent("address", address));
+		typo3.append(genBibTeXAttributeIfPresent("publisher", publisher));
+		typo3.append(genBibTeXAttributeIfPresent("journal", journal));
+		typo3.append(genBibTeXAttributeIfPresent("location", location));
+		typo3.append(genBibTeXAttributeIfPresent("school", school));
+		typo3.append(genBibTeXAttributeIfPresent("pages", pages));
+		typo3.append(genBibTeXAttributeIfPresent("doi", doi));
+		typo3.append(genBibTeXAttributeIfPresent("isbn", isbn));
+		typo3.append(genBibTeXAttributeIfPresent("issn", issn));
+		typo3.append(genBibTeXAttributeIfPresent("note", note));
+		typo3.append(genBibTeXAttributeIfPresent("tags", tags.stream().reduce((a, b) -> a + ", " + b).orElseGet(() -> "")));
 
-		return typo3 + "\n}";
+		typo3.append("\n}");
+		
+		return typo3.toString();
 	}
 	
 	public String getPaperURL() {

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -26,21 +26,21 @@ import de.mibtex.export.ExportTypo3Bibtex;
  *
  */
 public class Typo3Entry implements Comparable<Typo3Entry> {
-	private static final String PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers";
+	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
-		TO_URL_OVERWRITES.put("&auml;", "ï¿½");
-		TO_URL_OVERWRITES.put("&ouml;", "ï¿½");
-		TO_URL_OVERWRITES.put("&uuml;", "ï¿½");
-		TO_URL_OVERWRITES.put("&Auml;", "ï¿½");
-		TO_URL_OVERWRITES.put("&Ouml;", "ï¿½");
-		TO_URL_OVERWRITES.put("&Uuml;", "ï¿½");
+		TO_URL_OVERWRITES.put("&auml;", "ä");
+		TO_URL_OVERWRITES.put("&ouml;", "ö");
+		TO_URL_OVERWRITES.put("&uuml;", "ü");
+		TO_URL_OVERWRITES.put("&Auml;", "Ä");
+		TO_URL_OVERWRITES.put("&Ouml;", "Ö");
+		TO_URL_OVERWRITES.put("&Uuml;", "Ü");
 		TO_URL_OVERWRITES.put("&8211;", "-");
 		TO_URL_OVERWRITES.put("?", "?");
 		TO_URL_OVERWRITES.put(":", ":");
 		TO_URL_OVERWRITES.put("/", "/");
 		TO_URL_OVERWRITES.put("#", "#");
-		TO_URL_OVERWRITES.put("&szlig;", "ï¿½");
+		TO_URL_OVERWRITES.put("&szlig;", "ß");
 	}
 	
 	public final BibtexEntry source;
@@ -70,6 +70,9 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	public String note;
 	
 	public List<String> tags;
+	
+	// Not set automatically, only with modifiers
+	public String url;
 	
 	public Typo3Entry(BibtexEntry bib, Map<String, String> variables) {
 		this.source = bib;
@@ -132,15 +135,16 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		typo3.append(genBibTeXAttributeIfPresent("issn", issn));
 		typo3.append(genBibTeXAttributeIfPresent("note", note));
 		typo3.append(genBibTeXAttributeIfPresent("tags", tags.stream().reduce((a, b) -> a + ", " + b).orElseGet(() -> "")));
-
+		typo3.append(genBibTeXAttributeIfPresent("url", url));
+		
 		typo3.append("\n}");
 		
 		return typo3.toString();
 	}
 	
-	public String getPaperURL() {
-		StringBuilder b = new StringBuilder();
-		b.append(PAPER_REPO_URL);
+	public String getPaperUrlInSoftVarERepo() {
+		final StringBuilder b = new StringBuilder();
+		b.append(SOFTVARE_PAPER_REPO_URL);
 		b.append("/blob/master/");
 		b.append(year);
 		b.append("/");

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -26,6 +26,7 @@ import de.mibtex.export.ExportTypo3Bibtex;
  *
  */
 public class Typo3Entry implements Comparable<Typo3Entry> {
+	private static final String PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
 		TO_URL_OVERWRITES.put("&auml;", "ä");
@@ -51,6 +52,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	public String title;
 	public List<String> authors;
 	public List<String> editors;
+	public String venueVariable; // the variable used in the booktitle field in BibTags
 	public String booktitle;
 	public String address;
 	public String publisher;
@@ -58,6 +60,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	public String location;
 	public String school;
 	public String pages;
+	public String month;
 	public int year;
 	
 	public String doi;
@@ -86,6 +89,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		
 		this.title = makeTypo3Safe(bib.title);
 		this.year = bib.year;
+		this.month = bib.getAttribute(BibTeXEntry.KEY_MONTH);
 
 		this.address = makeTypo3Safe(lookup(bib.getAttribute(BibTeXEntry.KEY_ADDRESS), variables));
 		this.publisher = makeTypo3Safe(lookup(bib.getAttribute(BibTeXEntry.KEY_PUBLISHER), variables));
@@ -101,7 +105,8 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		
 		this.note = makeTypo3Safe(bib.getAttribute(BibTeXEntry.KEY_NOTE));
 
-		this.booktitle = parseBooktitle(bib, variables);		
+		this.booktitle = parseBooktitle(bib, variables);
+		this.venueVariable = bib.getAttribute(BibTeXEntry.KEY_BOOKTITLE);
 		this.tags = parseTags(bib);
 	}
 
@@ -113,6 +118,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		typo3 += genAuthorList();
 		typo3 += genBibTeXAttributeIfPresent("title", title);
 		typo3 += genBibTeXAttributeIfPresent("year", Integer.toString(year));
+		typo3 += genBibTeXAttributeIfPresent("month", month);
 		typo3 += genBibTeXAttributeIfPresent("booktitle", booktitle);
 		typo3 += genBibTeXAttributeIfPresent("address", address);
 		typo3 += genBibTeXAttributeIfPresent("publisher", publisher);
@@ -127,6 +133,20 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		typo3 += genBibTeXAttributeIfPresent("tags", tags.stream().reduce((a, b) -> a + ", " + b).orElseGet(() -> ""));
 
 		return typo3 + "\n}";
+	}
+	
+	public String getPaperURL() {
+		StringBuilder b = new StringBuilder();
+		b.append(PAPER_REPO_URL);
+		b.append("/blob/master/");
+		b.append(year);
+		b.append("/");
+		b.append(year);
+		b.append("-");
+		b.append(venueVariable);
+		b.append("-");
+		b.append(this.source.getLastnameOfFirstAuthor());
+		return b.toString();
 	}
 	
 	private String genAuthorList() {

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -156,7 +156,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 			b.append(venue);
 		}
 		b.append("-");
-		b.append(makeTypo3Safe(this.source.getLastnameOfFirstAuthor()));
+		b.append(BibtexEntry.toURL(this.source.getLastnameOfFirstAuthor()));
 		b.append(".pdf");
 		return b.toString();
 	}
@@ -222,18 +222,13 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	}
 	
 	private static String parseVenue(BibtexEntry bib, final Map<String, String> variables) {
-		// If the key has a colon, then it separates the author names from the venue.
-		// Otherwise, we have entries such as books or theses for which no specific venue or journal exists.
-		if (variables.containsKey(bib.key)) {
-			return bib.venue;
-		} else if (bib.key.contains(":")) {
-			// extract abrv from key
-			final int shortVenueBegin = bib.key.indexOf(':') + 1;
-			final int shortVenueEnd = Util.indexOfFirstMatch(bib.key, Character::isDigit, shortVenueBegin);
-			return bib.key.substring(shortVenueBegin, shortVenueEnd);
-		} else {
+		// If the venue is a not just a single word but a long name, we don't have a short venue name.
+		if (Util.indexOfFirstMatch(bib.venue, Character::isWhitespace) < bib.venue.length()) {
 			return "";
 		}
+
+		// Remove parenthesis such that, for example, "(techreport)" becomes "techreport".
+		return bib.venue.replaceAll("[()]", "").trim();
 	}
 	
 	private static List<String> parseTags(BibtexEntry bib) {

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -26,7 +26,7 @@ import de.mibtex.export.ExportTypo3Bibtex;
  *
  */
 public class Typo3Entry implements Comparable<Typo3Entry> {
-	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers";
+	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers/raw/master/";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
 		TO_URL_OVERWRITES.put("&auml;", "ä");
@@ -147,7 +147,6 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		
 		final StringBuilder b = new StringBuilder();
 		b.append(SOFTVARE_PAPER_REPO_URL);
-		b.append("/blob/master/");
 		b.append(year);
 		b.append("/");
 		b.append(year);

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -29,18 +29,18 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers/raw/master/";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
-		TO_URL_OVERWRITES.put("&auml;", "ä");
-		TO_URL_OVERWRITES.put("&ouml;", "ö");
-		TO_URL_OVERWRITES.put("&uuml;", "ü");
-		TO_URL_OVERWRITES.put("&Auml;", "Ä");
-		TO_URL_OVERWRITES.put("&Ouml;", "Ö");
-		TO_URL_OVERWRITES.put("&Uuml;", "Ü");
+		TO_URL_OVERWRITES.put("&auml;", "Ã¤");
+		TO_URL_OVERWRITES.put("&ouml;", "Ã¶");
+		TO_URL_OVERWRITES.put("&uuml;", "Ã¼");
+		TO_URL_OVERWRITES.put("&Auml;", "Ã„");
+		TO_URL_OVERWRITES.put("&Ouml;", "Ã–");
+		TO_URL_OVERWRITES.put("&Uuml;", "Ãœ");
 		TO_URL_OVERWRITES.put("&8211;", "-");
 		TO_URL_OVERWRITES.put("?", "?");
 		TO_URL_OVERWRITES.put(":", ":");
 		TO_URL_OVERWRITES.put("/", "/");
 		TO_URL_OVERWRITES.put("#", "#");
-		TO_URL_OVERWRITES.put("&szlig;", "ß");
+		TO_URL_OVERWRITES.put("&szlig;", "ÃŸ");
 	}
 	
 	public final BibtexEntry source;

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -92,7 +92,7 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 		
 		this.title = makeTypo3Safe(bib.title);
 		this.year = bib.year;
-		this.month = bib.getAttribute(BibTeXEntry.KEY_MONTH);
+		this.month = bib.getMonthAsNumber().map(i -> i.toString()).orElse("");
 
 		this.address = makeTypo3Safe(lookup(bib.getAttribute(BibTeXEntry.KEY_ADDRESS), variables));
 		this.publisher = makeTypo3Safe(lookup(bib.getAttribute(BibTeXEntry.KEY_PUBLISHER), variables));

--- a/MibTeX/src/de/mibtex/export/typo3/Util.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Util.java
@@ -117,4 +117,28 @@ public class Util {
 				.reduce(Function.identity(), Function::compose)
 				.apply(tags);
 	}
+	
+	/**
+	 * Find the first character in the given string that meets the given condition.
+	 * Return that characters index.
+	 * @return The index of the first character in the given string meeting the given condition.
+	 */
+	public static int indexOfFirstMatch(String string, Predicate<Character> condition) {
+		return indexOfFirstMatch(string, condition, 0);
+	}
+	
+	/**
+	 * Find the first character at or after the given index in the given string that meets the given condition.
+	 * Return that characters index.
+	 * @param fromIndex The index in the string from which the search should begin. Characters with indices < fromIndex will not be considered.
+	 * @return The index of the first character in the given string meeting the given condition.
+	 */
+	public static int indexOfFirstMatch(String string, Predicate<Character> condition, int fromIndex) {
+		for (int i = fromIndex; i < string.length(); ++i) {
+			if (condition.test(string.charAt(i))) {
+				return i;
+			}
+		}
+		return string.length();
+	}
 }


### PR DESCRIPTION
- Automatically add link to Typo3 entries for SoftVarE papers. Links point to https://github.com/SoftVarE-Group/Papers and have the naming pattern 
`https://github.com/SoftVarE-Group/Papers/blob/master/<year>/<year>-<venue>-<last name of first author>`
- Integrated, refined, and extended `LatexPublisher` class from Thomas to clean LaTeX projects. Primarily used for cleanup upon camera-ready submissions
- some bugfixes
- some code cleaning