### PR TITLE
Generate Preprint Links Only if Preprint Exists

### DIFF
--- a/MibTeX/src/de/mibtex/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/BibtexCleaner.java
@@ -21,7 +21,7 @@ public class BibtexCleaner {
 
 	public static void main(String[] args) {
 		attributesToRemove = Arrays.asList(
-//				  DOI,
+				  DOI,
 				  "issn",
 				  "isbn",
 				  "url",

--- a/MibTeX/src/de/mibtex/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/BibtexCleaner.java
@@ -1,4 +1,4 @@
-package de.mibtex.clean;
+package de.mibtex;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/MibTeX/src/de/mibtex/LatexPublisher.java
+++ b/MibTeX/src/de/mibtex/LatexPublisher.java
@@ -4,7 +4,7 @@
  * 
  * https://github.com/tthuem/MibTeX
  */
-package de.mibtex.clean;
+package de.mibtex;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
+++ b/MibTeX/src/de/mibtex/clean/BibtexCleaner.java
@@ -16,11 +16,12 @@ import java.util.List;
  * 
  */
 public class BibtexCleaner {
+	private static final String DOI = "doi";
 	private static List<String> attributesToRemove;
 
 	public static void main(String[] args) {
 		attributesToRemove = Arrays.asList(
-				  "doi",
+//				  DOI,
 				  "issn",
 				  "isbn",
 				  "url",
@@ -30,18 +31,19 @@ public class BibtexCleaner {
 				);
 		
 		File file = new File(args[0]);
-		processBibtexFile(file);
-	}
 
-	public static void processDirectory(File dir) {
-		for (File file : dir.listFiles()) {
-			if (file.getName().endsWith(".bib"))
-				processBibtexFile(file);
+		String suffix = "-cleaned";
+
+		if (!attributesToRemove.contains(DOI)) {
+			suffix += "-withdois";
 		}
+
+		System.out.println("Cleaning " + file + " to " + suffix);
+		processBibtexFile(file, suffix);
 	}
 
-	public static void processBibtexFile(File file) {
-		String filename = file.getAbsolutePath().replaceAll("[.]bib$", "-cleaned.bib");
+	public static void processBibtexFile(File file, String suffix) {
+		String filename = file.getAbsolutePath().replaceAll("[.]bib$", suffix + ".bib");
 		File newFile = new File(filename);
 		try {
 			BufferedReader in = new BufferedReader(new FileReader(file));

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -93,7 +93,7 @@ public class ExportTypo3Bibtex extends Export {
             , whenKeyIs("AMK+:GPCE16", softVarEURLFile("2016-GPCE-Al-Hajjaji-Demo"))
             , whenKeyIs("TLK:SPLC16", softVarEURLFile("2016-SPLC-Thuem-Tutorial"))
             , whenKeyIs("RLB+:AOSDtool14", softVarEURLFile("2014-AOSD-Rebelo-Demo"))
-            , whenKeyIs("T15", softVarEURLFile("2015-PhD-Thuem"))
+            , whenKeyIs("Thuem15", softVarEURLFile("2015-PhD-Thuem"))
             , whenKeyIs("TSP+:ISRN12", softVarEURLFile("2012-ISRN-Thuem"))
             , whenKeyIs("SSS+16", softVarEURLFile("2016-WSRE-Schink"))
             , whenKeyIs("JMJ+19", softVarEURLFile("2019-SPP1593-Jung"))

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -106,10 +106,10 @@ public class ExportTypo3Bibtex extends Export {
 			
 			// Other custom solutions
 			, whenKeyIs("DGT:EMSE21", SWITCH_AUTHORS_TO_EDITORS)
-			, whenKeyIs("Y21", KEEP_URL_IF_PRESENT)
+			, whenKeyIs("Young21", KEEP_URL_IF_PRESENT)
 
 			// Resolving duplicates
-			, whenKeyIs("Y21", MARK_AS_PHDTHESIS)
+			, whenKeyIs("Young21", MARK_AS_PHDTHESIS)
 			, whenKeyIs("KJN+:SE21", MARK_AS_EXTENDED_ABSTRACT)
 			, whenKeyIs("RSC+:SE21", MARK_AS_EXTENDED_ABSTRACT)
 			, whenKeyIs("TKK+:SPLC19", MARK_AS_EXTENDED_ABSTRACT)

--- a/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
+++ b/MibTeX/src/de/mibtex/export/ExportTypo3Bibtex.java
@@ -88,7 +88,6 @@ public class ExportTypo3Bibtex extends Export {
 			  TAG_IF_THOMAS_IS_EDITOR
 			, TAG_IF_SOFTVARE
 			, MARK_IF_TO_APPEAR
-            , KEEP_URL_IF_PRESENT // use this modifier (at least) when exporting theses for our website
 
             // Website
             , whenKeyIs("AMK+:GPCE16", softVarEURLFile("2016-GPCE-Al-Hajjaji-Demo"))
@@ -102,7 +101,10 @@ public class ExportTypo3Bibtex extends Export {
             , whenKeyIs("TKS:ConfWS18", softVarEURLFile("2018-CONFWS-Thuem"))
             , whenKeyIs("TB12", CLEAR_URL)
             , whenKeyIs("MTS+17", CLEAR_URL)
-			, ADD_PAPER_LINK_IF_SOFTVARE
+			, Util.when(Filters.PREPRINT_EXISTS_IN_PDF_DIR_REL,
+					ADD_PAPER_LINK_IF_SOFTVARE,
+					KEEP_URL_IF_PRESENT
+			)
 			
 			// Other custom solutions
 			, whenKeyIs("DGT:EMSE21", SWITCH_AUTHORS_TO_EDITORS)

--- a/MibTeX/src/de/mibtex/export/typo3/Filters.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Filters.java
@@ -7,7 +7,10 @@
 package de.mibtex.export.typo3;
 
 import de.mibtex.BibtexEntry;
+import de.mibtex.BibtexViewer;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
@@ -91,6 +94,12 @@ public class Filters {
 
     public final static Predicate<Typo3Entry> SHOULD_BE_PUT_ON_WEBSITE = IS_SOFTVARE_PUBLICATION.or(THESIS_BY_SOFTVARE);
 
+	/**
+	 * The predicate returns true if the preprint for the given entry exists in our SoftVarE/Papers repository.
+	 * This predicate expects a local clone of the repository to be located at {@link BibtexViewer#PDF_DIR_REL}.
+	 */
+	public final static Predicate<Typo3Entry> PREPRINT_EXISTS_IN_PDF_DIR_REL = t ->
+			Files.exists(Path.of(t.getPaperUrlInRepo(BibtexViewer.PDF_DIR_REL)));
 
     public static Predicate<Typo3Entry> hasAtLeastOneTagOf(final String... tags) {
         return b -> {

--- a/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Modifiers.java
@@ -43,9 +43,12 @@ public class Modifiers {
 	public static final Function<Typo3Entry, Typo3Entry> MARK_AS_PROJECTTHESIS =
 			appendToTitle("(Project Thesis)");
 
+	public static Function<Typo3Entry, Typo3Entry> SET_SOFTVARE_URL =
+			sideffect(t -> t.url = t.getPaperUrlInSoftVarERepo());
+
 	/** misc **/
 	public static final Function<Typo3Entry, Typo3Entry> ADD_PAPER_LINK_IF_SOFTVARE = 
-			Util.when(Filters.IS_SOFTVARE_PUBLICATION, setSoftVarEURL());
+			Util.when(Filters.IS_SOFTVARE_PUBLICATION, SET_SOFTVARE_URL);
 	public static final Function<Typo3Entry, Typo3Entry> KEEP_URL_IF_PRESENT =
 			sideffect(t -> {
 				final String url = t.source.getAttribute("url");
@@ -78,10 +81,6 @@ public class Modifiers {
 	
 	public static Function<Typo3Entry, Typo3Entry> addTag(String tag) {
 		return sideffect(t -> t.tags.add(tag));
-	}
-	
-	public static Function<Typo3Entry, Typo3Entry> setSoftVarEURL() {
-		return sideffect(t -> t.url = t.getPaperUrlInSoftVarERepo());
 	}
 
     public static Function<Typo3Entry, Typo3Entry> softVarEURLFile(final String pdfName) {

--- a/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
+++ b/MibTeX/src/de/mibtex/export/typo3/Typo3Entry.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  *
  */
 public class Typo3Entry implements Comparable<Typo3Entry> {
-	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers/raw/master/";
+	private static final String SOFTVARE_PAPER_REPO_URL = "https://github.com/SoftVarE-Group/Papers/raw/main/";
 	private static final Map<String, String> TO_URL_OVERWRITES = new HashMap<>();
 	static {
 		TO_URL_OVERWRITES.put("&auml;", "ä");
@@ -146,35 +146,46 @@ public class Typo3Entry implements Comparable<Typo3Entry> {
 	}
 	
 	public String getPaperUrlInSoftVarERepo() {
+		return getPaperUrlInRepo(SOFTVARE_PAPER_REPO_URL);
+	}
+
+	public String getPaperUrlInRepo(final String reponame) {
 		final String venue = makeTypo3Safe(shortVenue);
-		
+
 		final StringBuilder pdfname = new StringBuilder();
-        pdfname.append(year);
-        if (Filters.IS_TECHREPORT.test(this)) {
-            pdfname.append("-");
-            pdfname.append("TR");
-        } else if (!venue.isEmpty()) {
-            pdfname.append("-");
-            pdfname.append(venue);
+		pdfname.append(year);
+		if (Filters.IS_TECHREPORT.test(this)) {
+			pdfname.append("-");
+			pdfname.append("TR");
+		} else if (!venue.isEmpty()) {
+			pdfname.append("-");
+			pdfname.append(venue);
 		}
-        else if (publisherVarname.equals("GI")) {
-            pdfname.append("-");
-            pdfname.append(publisherVarname);
-        }
-        pdfname.append("-");
-        pdfname.append(BibtexEntry.toURL(this.source.getLastnameOfFirstAuthor()));
-		return getPaperUrlInSoftVarERepo(year, pdfname.toString());
+		else if (publisherVarname.equals("GI")) {
+			pdfname.append("-");
+			pdfname.append(publisherVarname);
+		}
+		pdfname.append("-");
+		pdfname.append(BibtexEntry.toURL(this.source.getLastnameOfFirstAuthor()));
+		return getPaperUrlInRepo(reponame, year, pdfname.toString());
 	}
 
     public static String getPaperUrlInSoftVarERepo(int year, final String pdfname) {
-        final StringBuilder b = new StringBuilder();
-        b.append(SOFTVARE_PAPER_REPO_URL);
-        b.append(year);
-        b.append("/");
-        b.append(pdfname);
-        b.append(".pdf");
-        return b.toString();
+        return getPaperUrlInRepo(SOFTVARE_PAPER_REPO_URL, year, pdfname);
     }
+
+	public static String getPaperUrlInRepo(String reponame, int year, final String pdfname) {
+		final StringBuilder b = new StringBuilder();
+		b.append(reponame);
+		if (!reponame.endsWith("/") && !reponame.endsWith("\\")) {
+			b.append("/");
+		}
+		b.append(year);
+		b.append("/");
+		b.append(pdfname);
+		b.append(".pdf");
+		return b.toString();
+	}
 	
 	private String genAuthorList() {
 		List<String> persons;


### PR DESCRIPTION
As discussed in our meeting, links to preprints are now generated for SoftVarE papers only if such a preprint exists in the repository. MibTeX therefore requires a local clone of our [papers repository](https://github.com/SoftVarE-Group/Papers). The location of the clone is specified via the property `pdf-dir-rel` in the ini-file (and not `pdf-dir` because apparently, `pdf-dir` is a relative path and `pdf-dir-rel` is absolute (which we need here)). This new feature also prevents the generation of dead links for preprints.

Other changes:
- Updated hardcoded BibTags keys for custom rules.
- Updated URL to preprint repository, which changed due to branch renaming
- added code for cleaning literature files and keeping dois (required for ACM camera ready)
- flattened irritating `clean` package