### PR TITLE
refactor: replace ini4j lib by custom impl.

### DIFF
--- a/MibTeX/pom.xml
+++ b/MibTeX/pom.xml
@@ -40,11 +40,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.ini4j</groupId>
-            <artifactId>ini4j</artifactId>
-            <version>0.5.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.jbibtex</groupId>
             <artifactId>jbibtex</artifactId>
             <version>1.0.19</version>

--- a/MibTeX/src/de/mibtex/Ini.java
+++ b/MibTeX/src/de/mibtex/Ini.java
@@ -1,6 +1,7 @@
 package de.mibtex;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
@@ -46,6 +47,10 @@ public class Ini {
             final Stream<String> lines = b.lines();
             return fromLineStream(lines);
         }
+    }
+
+    public static Ini fromFile(File path) throws IOException {
+        return fromFile(path.toPath());
     }
 
     public static boolean parseBool(String val) {

--- a/MibTeX/src/de/mibtex/Ini.java
+++ b/MibTeX/src/de/mibtex/Ini.java
@@ -1,0 +1,54 @@
+package de.mibtex;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class Ini {
+    private final static String ASSIGNMENT_OP = "=";
+
+    private Map<String, String> options;
+
+    private Ini () {
+        options = new HashMap<>();
+    }
+
+    public void put(String option, String value) {
+        options.put(option, value);
+    }
+
+    public String get(String option) {
+        return options.get(option);
+    }
+
+    public static Ini fromLineStream(Stream<String> lines) {
+        Ini ini = new Ini();
+        lines
+            .filter(l -> !l.contains("[options]"))
+            .forEach(line -> {
+                String[] parts = line.split(ASSIGNMENT_OP, -1);
+                if (parts.length == 2) {
+                    ini.put(parts[0], parts[1]);
+                } else {
+                    System.err.println("Ignoring unexpected line \"" + line + "\" in ini file!");
+                }
+        });
+
+        return ini;
+    }
+
+    public static Ini fromFile(Path path) throws IOException {
+        try (BufferedReader b = Files.newBufferedReader(path)) {
+            final Stream<String> lines = b.lines();
+            return fromLineStream(lines);
+        }
+    }
+
+    public static boolean parseBool(String val) {
+        return Boolean.parseBoolean(val);
+    }
+}

--- a/MibTeX/src/de/mibtex/citationservice/CitationService.java
+++ b/MibTeX/src/de/mibtex/citationservice/CitationService.java
@@ -9,7 +9,7 @@ package de.mibtex.citationservice;
 import java.io.File;
 import java.io.IOException;
 
-import org.ini4j.Ini;
+import de.mibtex.Ini;
 
 /**
  * A class to export the citations from scholar for each BibTeX entry
@@ -33,14 +33,14 @@ public class CitationService {
 		if (iniFile.exists()) {
 			Ini ini = null;
 			try {
-				ini = new Ini(iniFile);
+				ini = Ini.fromFile(iniFile);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
             if (ini != null) {
-            	CITATION_DIR = ini.get("options", "citation-dir");
+            	CITATION_DIR = ini.get("citation-dir");
                 if (CITATION_DIR == null || CITATION_DIR.isEmpty()) {
-                    CITATION_DIR = ini.get("options", "bibtex-dir");
+                    CITATION_DIR = ini.get("bibtex-dir");
                 }
             }
 		} else {


### PR DESCRIPTION
fixes https://github.com/TUBS-ISF/MibTeX/security/dependabot/1

Since there is no newer version of the ini4j library, the only solution was to remove it or ignore the error. Both solutions would have been fine actually but I used this opportunity to replace the library by a simple custom implementation, which gives us more control on how ini files should be formatted.

I also used this opportunity to simplify the main method.